### PR TITLE
Configurable publish batch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,20 @@ Maven
 
 ### Publish!
 
+Publish messages to topic. Thresholds can be configured through options:
+- Delay Threshold: Counting from the time that the first message is queued, once this delay has passed, then send the batch. The default value is 100 millisecond, which is good for large amount of messages.
+- Message Count Threshold: Once this many messages are queued, send all of the messages in a single call, even if the delay threshold hasn't elapsed yet. The default value is 10 messages.
+- Request Byte Threshold: Once the number of bytes in the batched request reaches this threshold, send all of the messages in a single call, even if neither the delay or message count thresholds have been exceeded yet. The default value is 1000 bytes.
+
 ```clj
 (require '[jonotin.core :as jonotin])
 
 (jonotin/publish! {:project-name "my-gcloud-project-id"
                    :topic-name "my-topic"
-                   :messages ["msg1" "msg2"]})
+                   :messages ["msg1" "msg2"]
+		   :options {:request-byte-threshold 100
+                             :element-count-threshold 10
+                             :delay-threshold 1000}})
 ```
 
 ### Subscribe!

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jonotin "0.3.2"
+(defproject jonotin "0.3.3"
   :description "Google Pub/Sub Java SDK wrapper"
   :url "https://github.com/iprally/jonotin"
   :license {:name "The MIT License"

--- a/src/jonotin/core.clj
+++ b/src/jonotin/core.clj
@@ -48,16 +48,16 @@
     (.awaitRunning (.startAsync subscriber))
     (.awaitTerminated subscriber)))
 
-(defn publish! [{:keys [project-name topic-name messages]}]
+(defn publish! [{:keys [project-name topic-name messages options]}]
   (when (> (count messages) 10000)
     (throw (ex-info "Message count over safety limit"
                     {:type :jonotin/batch-size-limit
                      :message-count (count messages)}))) 
   (let [topic (ProjectTopicName/of project-name topic-name)
         batching-settings (-> (BatchingSettings/newBuilder)
-                              (.setRequestByteThreshold 1000)
-                              (.setElementCountThreshold 10)
-                              (.setDelayThreshold (Duration/ofMillis 1000))
+                              (.setRequestByteThreshold (or (:request-byte-threshold options) 1000))
+                              (.setElementCountThreshold (or (:element-count-threshold options) 10))
+                              (.setDelayThreshold (Duration/ofMillis (or (:delay-threshold options) 100)))
                               .build)
         publisher (-> (Publisher/newBuilder topic)
                       (.setBatchingSettings batching-settings)


### PR DESCRIPTION
Noticed that previous default thresholds slow down publishing single message so added configs for batching.