### PR TITLE
Add support for Google Cloud Pub/Sub emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Subscribe with concurrency control.
                                         (println "Oops!" e))})
   ```
 
-## Testing
+## Testing your application
 
 jonotin supports Google Cloud Pub/Sub emulator. When environment variable `PUBSUB_EMULATOR_HOST` is set, then jonotin will use emulator instead of the real GCP Pub/Sub API.
 
@@ -99,20 +99,41 @@ Note that on the first run, no topics or subscriptions exist in the emulator. jo
 (require '[jonotin.emulator :as emulator])
 
 ;; Create a topic
-(emulator/create-topic "my-project" "my-topic")
+(emulator/create-topic "project-name" "topic-name")
 
-;; Delete a topic
-(emulator/delete-topic "my-project" "my-topic")
+;; Get the topic
+(emulator/get-topic "project-name" "topic-name")
 
-;; Create a pull subscription
-(emulator/create-pull-subscription "my-project" "my-topic" "my-pull-subscription")
+;; Delete the topic
+(emulator/delete-topic "project-name" "topic-name")
 
-;; Delete a pull subscription
-(emulator/delete-pull-subscription "my-project" "my-topic" "my-pull-subscription")
+;; Create a subscription
+(emulator/create-subscription "project-name" "topic-name" "subscription-name")
 
-;; Create a push subscription
-(emulator/create-push-subscription "my-project" "my-topic" "my-push-subscription")
+;; Create a subscription with custom ack-deadline-seconds
+(emulator/create-subscription "project-name" "topic-name" "subscription-name" {:ack-deadline-seconds 600})
 
-;; Delete a push subscription
-(emulator/delete-push-subscription "my-project" "my-topic" "my-push-subscription")
+;; Get the subscription
+(emulator/get-subscription "project-name" "subscription-name")
+
+;; Delete the subscription
+(emulator/delete-subscription "project-name" "subscription-name")
+```
+
+To be sure that jonotin in your test suite targets Pub/Sub emulator, use
+
+```clojure
+(emulator/ensure-host-configured)
+```
+
+where appropriate. This function will throw if `PUBSUB_EMULATOR_HOST` is not configured.
+
+# Development
+
+## Testing jonotin
+
+Once you've set up the Google Cloud Pub/Sub emulator and configured `PUBSUB_EMULATOR_HOST`, use Leiningen to run the tests:
+
+```bash
+lein test
 ```

--- a/README.md
+++ b/README.md
@@ -85,15 +85,16 @@ jonotin supports Google Cloud Pub/Sub emulator. When environment variable `PUBSU
 
 To set up the emulator, follow [Testing apps locally with the emulator](https://cloud.google.com/pubsub/docs/emulator) guide for setting up the emulator.
 
-The guide features a command for setting `PUBSUB_EMULATOR_HOST`:
+Once your emulator is up-and-running, configure `PUBSUB_EMULATOR_HOST`:
 
 ```bash
-$(gcloud beta emulators pubsub env-init)
+$(gcloud beta emulators pubsub env-init) && echo $PUBSUB_EMULATOR_HOST
+# => localhost:8085
 ```
 
-Run your application and witness jonotin diligently using the emulator.
+Now run your application and witness jonotin diligently using the emulator.
 
-Note that on the first run, no topics or subscriptions exist in the emulator. jonotin includes helpers for creating/removing those:
+Note that emulator is ephemeral and no topics or subscriptions exist when it starts. jonotin includes helpers for creating/removing those:
 
 ```clojure
 (require '[jonotin.emulator :as emulator])

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Dead-simple Google Cloud Pub/Sub from Clojure. jonotin is a never used Finnish w
 
 Leiningen/Boot
 ```clj
-[jonotin "0.3.5"]
+[jonotin "0.4.0"]
 ```
 
 Clojure CLI/deps.edn
 ```clj
-jonotin {:mvn/version "0.3.5"}
+jonotin {:mvn/version "0.4.0"}
 ```
 
 Gradle
 ```clj
-compile 'jonotin:jonotin:0.3.5'
+compile 'jonotin:jonotin:0.4.0'
 ```
 
 Maven
@@ -24,7 +24,7 @@ Maven
 <dependency>
   <groupId>jonotin</groupId>
   <artifactId>jonotin</artifactId>
-  <version>0.3.5</version>
+  <version>0.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,3 +78,41 @@ Subscribe with concurrency control.
                      :handle-error-fn (fn [e]
                                         (println "Oops!" e))})
   ```
+
+## Testing
+
+jonotin supports Google Cloud Pub/Sub emulator. When environment variable `PUBSUB_EMULATOR_HOST` is set, then jonotin will use emulator instead of the real GCP Pub/Sub API.
+
+To set up the emulator, follow [Testing apps locally with the emulator](https://cloud.google.com/pubsub/docs/emulator) guide for setting up the emulator.
+
+The guide features a command for setting `PUBSUB_EMULATOR_HOST`:
+
+```bash
+$(gcloud beta emulators pubsub env-init)
+```
+
+Run your application and witness jonotin diligently using the emulator.
+
+Note that on the first run, no topics or subscriptions exist in the emulator. jonotin includes helpers for creating/removing those:
+
+```clojure
+(require '[jonotin.emulator :as emulator])
+
+;; Create a topic
+(emulator/create-topic "my-project" "my-topic")
+
+;; Delete a topic
+(emulator/delete-topic "my-project" "my-topic")
+
+;; Create a pull subscription
+(emulator/create-pull-subscription "my-project" "my-topic" "my-pull-subscription")
+
+;; Delete a pull subscription
+(emulator/delete-pull-subscription "my-project" "my-topic" "my-pull-subscription")
+
+;; Create a push subscription
+(emulator/create-push-subscription "my-project" "my-topic" "my-push-subscription")
+
+;; Delete a push subscription
+(emulator/delete-push-subscription "my-project" "my-topic" "my-push-subscription")
+```

--- a/README.md
+++ b/README.md
@@ -132,8 +132,17 @@ where appropriate. This function will throw if `PUBSUB_EMULATOR_HOST` is not con
 
 ## Testing jonotin
 
-Once you've set up the Google Cloud Pub/Sub emulator and configured `PUBSUB_EMULATOR_HOST`, use Leiningen to run the tests:
+Once you've set up the Google Cloud Pub/Sub emulator, start the emulator for jonotin test project:
 
 ```bash
+gcloud beta emulators pubsub start --project=jonotin-test-emulator
+```
+
+In another shell session, configure `PUBSUB_EMULATOR_HOST` and run the tests:
+
+```bash
+$(gcloud beta emulators pubsub env-init) && echo $PUBSUB_EMULATOR_HOST
+# => localhost:8085
+
 lein test
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jonotin "0.3.5"
+(defproject jonotin "0.4.0"
   :description "Google Pub/Sub Java SDK wrapper"
   :url "https://github.com/iprally/jonotin"
   :license {:name "The MIT License"

--- a/src/jonotin/core.clj
+++ b/src/jonotin/core.clj
@@ -43,7 +43,7 @@
         subscriber-builder (cond-> (Subscriber/newBuilder subscription-name-obj msg-receiver)
                              (:parallel-pull-count options) (.setParallelPullCount (:parallel-pull-count options))
                              (:executor-thread-count options) (.setExecutorProvider (get-executor-provider options))
-                             emulator-channel (emulator/configure emulator-channel))
+                             emulator-channel (emulator/set-builder-options emulator-channel))
         subscriber (.build subscriber-builder)
         listener (proxy [ApiService$Listener] []
                    (failed [from failure]
@@ -68,7 +68,7 @@
                            (emulator/build-channel))
         publisher-builder (cond-> (Publisher/newBuilder topic)
                             batching-settings (.setBatchingSettings batching-settings)
-                            emulator-channel (emulator/configure emulator-channel))
+                            emulator-channel (emulator/set-builder-options emulator-channel))
         publisher (.build publisher-builder)
         callback-fn (reify ApiFutureCallback
                       (onFailure [_ t]

--- a/src/jonotin/emulator.clj
+++ b/src/jonotin/emulator.clj
@@ -12,7 +12,7 @@
 
 (defn- ensure-host-configured []
   (when-not host-configured?
-    (throw (ex-info "Unable to use emulator without PUBSUB_EMULATOR_HOST"
+    (throw (ex-info "PUBSUB_EMULATOR_HOST is required when using Google Cloud Pub/Sub emulator"
                     {:type :jonotin/emulator-host-not-configured}))))
 
 (defn build-channel []
@@ -66,6 +66,10 @@
   (with-topic-admin-client
     #(.createTopic % (TopicName/of project-name topic-name))))
 
+(defn get-topic [project-name topic-name]
+  (with-topic-admin-client
+    #(.getTopic % (TopicName/of project-name topic-name))))
+
 (defn delete-topic [project-name topic-name]
   (with-topic-admin-client
     (fn [client]
@@ -80,6 +84,10 @@
             project-topic (TopicName/of project-name topic-name)
             push-config (PushConfig/getDefaultInstance)]
         (.createSubscription client project-subscription project-topic push-config ack-deadline-seconds)))))
+
+(defn get-subscription [project-name subscription-name]
+  (with-subscription-admin-client
+    #(.getSubscription % (SubscriptionName/of project-name subscription-name))))
 
 (defn delete-subscription [project-name subscription-name]
   (with-subscription-admin-client

--- a/src/jonotin/emulator.clj
+++ b/src/jonotin/emulator.clj
@@ -1,0 +1,29 @@
+(ns jonotin.emulator
+  (:import (com.google.api.gax.core NoCredentialsProvider)
+           (com.google.api.gax.grpc GrpcTransportChannel)
+           (com.google.api.gax.rpc FixedTransportChannelProvider)
+           (io.grpc ManagedChannelBuilder)))
+
+(def pubsub-emulator-host (System/getenv "PUBSUB_EMULATOR_HOST"))
+
+(def host-configured? (boolean pubsub-emulator-host))
+
+(defn- ensure-host-configured []
+  (when-not host-configured?
+    (throw (ex-info "Unable to use emulator without PUBSUB_EMULATOR_HOST"
+                    {:type :jonotin/emulator-host-not-configured}))))
+
+(defn build-channel []
+  (ensure-host-configured)
+  (-> pubsub-emulator-host
+      (ManagedChannelBuilder/forTarget)
+      (.usePlaintext)
+      (.build)))
+
+(defn configure [builder emulator-channel]
+  (ensure-host-configured)
+  (-> builder
+      (.setCredentialsProvider (NoCredentialsProvider/create))
+      (.setChannelProvider (-> emulator-channel
+                               (GrpcTransportChannel/create)
+                               (FixedTransportChannelProvider/create)))))

--- a/src/jonotin/emulator.clj
+++ b/src/jonotin/emulator.clj
@@ -10,9 +10,9 @@
 
 (def host-configured? (boolean pubsub-emulator-host))
 
-(defn- ensure-host-configured []
+(defn ensure-host-configured []
   (when-not host-configured?
-    (throw (ex-info "PUBSUB_EMULATOR_HOST is required when using Google Cloud Pub/Sub emulator"
+    (throw (ex-info "PUBSUB_EMULATOR_HOST is required for using Google Cloud Pub/Sub emulator"
                     {:type :jonotin/emulator-host-not-configured}))))
 
 (defn build-channel []

--- a/src/jonotin/emulator.clj
+++ b/src/jonotin/emulator.clj
@@ -20,7 +20,7 @@
       (.usePlaintext)
       (.build)))
 
-(defn configure [builder emulator-channel]
+(defn set-builder-options [builder emulator-channel]
   (ensure-host-configured)
   (-> builder
       (.setCredentialsProvider (NoCredentialsProvider/create))

--- a/src/jonotin/emulator.clj
+++ b/src/jonotin/emulator.clj
@@ -38,26 +38,26 @@
                                         (GrpcTransportChannel/create)
                                         (FixedTransportChannelProvider/create)))))
 
-(defn with-topic-admin-client [fn]
+(defn with-topic-admin-client [f]
   (let [channel (build-channel)
         topic-admin-settings (-> (TopicAdminSettings/newBuilder)
                                  (set-admin-client-builder-options channel)
                                  (.build))
         topic-client (TopicAdminClient/create ^TopicAdminSettings topic-admin-settings)]
     (try
-      (fn topic-client)
+      (f topic-client)
       (finally
         (.shutdown topic-client)
         (.shutdown channel)))))
 
-(defn with-subscription-admin-client [fn]
+(defn with-subscription-admin-client [f]
   (let [channel (build-channel)
         subscription-admin-settings (-> (SubscriptionAdminSettings/newBuilder)
                                         (set-admin-client-builder-options channel)
                                         (.build))
         subscription-client (SubscriptionAdminClient/create ^SubscriptionAdminSettings subscription-admin-settings)]
     (try
-      (fn subscription-client)
+      (f subscription-client)
       (finally
         (.shutdown subscription-client)
         (.shutdown channel)))))

--- a/test/jonotin/core_test.clj
+++ b/test/jonotin/core_test.clj
@@ -1,0 +1,45 @@
+(ns jonotin.core-test
+  (:require [clojure.test :refer :all]
+            [jonotin.core :as core]
+            [jonotin.emulator :as emulator]
+            [jonotin.test-helpers :refer :all]))
+
+(use-fixtures :once ensure-emulator-host-configured)
+
+(deftest subscribe!-test
+  (let [successful-messages (atom 0)
+        errored-messages (atom 0)
+        topic-name (unique-topic-name)
+        subscription-name (unique-subscription-name)]
+    (emulator/create-topic project-name topic-name)
+    (emulator/create-subscription project-name topic-name subscription-name)
+    (in-parallel
+      (core/subscribe! {:project-name project-name
+                        :subscription-name subscription-name
+                        :handle-msg-fn #(case %
+                                          "normal" (swap! successful-messages inc)
+                                          "exceptional-retry" (throw (ex-info "" {::retry? true}))
+                                          "exceptional-no-retry" (throw (ex-info "" {::retry? false})))
+                        :handle-error-fn (fn [e]
+                                           (swap! errored-messages inc)
+                                           (if (::retry? (ex-data e))
+                                             {:ack false}
+                                             {:ack true}))}))
+    (core/publish! {:project-name project-name
+                    :topic-name topic-name
+                    :messages ["normal"
+                               "exceptional-retry"
+                               "normal"
+                               "exceptional-no-retry"
+                               "normal"]})
+    (Thread/sleep 500)
+    (is (= 3 @successful-messages))
+    (is (= 6 @errored-messages))))
+
+(deftest publish!-test
+  (let [topic-name (unique-topic-name)]
+    (emulator/create-topic project-name topic-name)
+    (is (= {:delivered-messages 2}
+           (core/publish! {:project-name project-name
+                           :topic-name topic-name
+                           :messages ["hello" "goodbye"]})))))

--- a/test/jonotin/emulator_test.clj
+++ b/test/jonotin/emulator_test.clj
@@ -1,0 +1,25 @@
+(ns jonotin.emulator-test
+  (:require [clojure.test :refer :all]
+            [jonotin.emulator :as emulator]))
+
+(def project-name "jonotin-test-emulator")
+
+(defn unique-topic-name []
+  (str "test-topic-" (random-uuid)))
+
+(defn unique-subscription-name []
+  (str "test-subscription-" (random-uuid)))
+
+(deftest topic-test
+  (let [topic-name (unique-topic-name)]
+    (is (= (emulator/create-topic project-name topic-name)
+           (emulator/get-topic project-name topic-name)))
+    (is (emulator/delete-topic project-name topic-name))))
+
+(deftest subscription-test
+  (let [topic-name (unique-topic-name)
+        subscription-name (unique-subscription-name)]
+    (is (emulator/create-topic project-name topic-name))
+    (is (= (emulator/create-subscription project-name topic-name subscription-name)
+           (emulator/get-subscription project-name subscription-name)))
+    (is (emulator/delete-subscription project-name subscription-name))))

--- a/test/jonotin/emulator_test.clj
+++ b/test/jonotin/emulator_test.clj
@@ -1,14 +1,7 @@
 (ns jonotin.emulator-test
   (:require [clojure.test :refer :all]
-            [jonotin.emulator :as emulator]))
-
-(def project-name "jonotin-test-emulator")
-
-(defn unique-topic-name []
-  (str "test-topic-" (random-uuid)))
-
-(defn unique-subscription-name []
-  (str "test-subscription-" (random-uuid)))
+            [jonotin.emulator :as emulator]
+            [jonotin.test-helpers :refer :all]))
 
 (deftest topic-test
   (let [topic-name (unique-topic-name)]

--- a/test/jonotin/test_helpers.clj
+++ b/test/jonotin/test_helpers.clj
@@ -1,0 +1,17 @@
+(ns jonotin.test-helpers
+  (:require [jonotin.emulator :as emulator]))
+
+(def project-name "jonotin-test-emulator")
+
+(defn unique-topic-name []
+  (str "test-topic-" (random-uuid)))
+
+(defn unique-subscription-name []
+  (str "test-subscription-" (random-uuid)))
+
+(defn ensure-emulator-host-configured [f]
+  (emulator/ensure-host-configured)
+  (f))
+
+(defmacro in-parallel [& body]
+  `(.start (Thread. (fn [] ~@body))))


### PR DESCRIPTION
Makes it possible to use jonotin with Google Cloud Pub/Sub emulator. 

I based my implementation on the official documentation: [Testing apps locally with the emulator](https://cloud.google.com/pubsub/docs/emulator) 

Also, adds tests to cover most of the existing and new functionality.