### PR TITLE
Skip calling shutdown on emulator channel when emulator is not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Dead-simple Google Cloud Pub/Sub from Clojure. jonotin is a never used Finnish w
 
 Leiningen/Boot
 ```clj
-[jonotin "0.4.0"]
+[jonotin "0.4.1"]
 ```
 
 Clojure CLI/deps.edn
 ```clj
-jonotin {:mvn/version "0.4.0"}
+jonotin {:mvn/version "0.4.1"}
 ```
 
 Gradle
 ```clj
-compile 'jonotin:jonotin:0.4.0'
+compile 'jonotin:jonotin:0.4.1'
 ```
 
 Maven
@@ -24,7 +24,7 @@ Maven
 <dependency>
   <groupId>jonotin</groupId>
   <artifactId>jonotin</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject jonotin "0.4.0"
+(defproject jonotin "0.4.1"
   :description "Google Pub/Sub Java SDK wrapper"
   :url "https://github.com/iprally/jonotin"
   :license {:name "The MIT License"

--- a/src/jonotin/core.clj
+++ b/src/jonotin/core.clj
@@ -51,7 +51,7 @@
     (.addListener subscriber listener (MoreExecutors/directExecutor))
     (.awaitRunning (.startAsync subscriber))
     (.awaitTerminated subscriber)
-    (.shutdown emulator-channel)))
+    (some-> emulator-channel .shutdown)))
 
 (defn publish! [{:keys [project-name topic-name messages options]}]
   (when (> (count messages) 10000)
@@ -90,5 +90,5 @@
         message-ids (.get (ApiFutures/allAsList futures))]
     (.shutdown publisher)
     (.awaitTermination publisher 5 java.util.concurrent.TimeUnit/MINUTES)
-    (.shutdown emulator-channel)
+    (some-> emulator-channel .shutdown)
     {:delivered-messages (count message-ids)}))


### PR DESCRIPTION
Fixes an issue introduced in #16 where `.shutdown` is called for emulator channel even when emulator is not in use (i.e. `emulator-channel` is `nil`).

Now the emulator channel shutdown happens only when emulator was actually used.